### PR TITLE
Added Wishlist entity, repository, and use cases

### DIFF
--- a/lib/domain/entities/wishlist_item.dart
+++ b/lib/domain/entities/wishlist_item.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+class WishlistItem extends Equatable {
+  final String productId;
+  final DateTime addedAt;
+
+  const WishlistItem({
+    required this.productId,
+    required this.addedAt,
+  });
+
+  @override
+  List<Object?> get props => [productId, addedAt];
+}

--- a/lib/domain/repositories/wishlist_repository.dart
+++ b/lib/domain/repositories/wishlist_repository.dart
@@ -1,0 +1,10 @@
+import 'package:dartz/dartz.dart';
+import '../entities/wishlist_item.dart';
+import '../../core/failure.dart';
+
+abstract class WishlistRepository {
+  Future<Either<Failure, List<WishlistItem>>> getWishlist();
+  Future<Either<Failure, void>> addToWishlist(String productId);
+  Future<Either<Failure, void>> removeFromWishlist(String productId);
+  Future<Either<Failure, bool>> isInWishlist(String productId);
+}

--- a/lib/domain/usecases/add_to_wishlist.dart
+++ b/lib/domain/usecases/add_to_wishlist.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../repositories/wishlist_repository.dart';
+import '../../core/failure.dart';
+
+class AddToWishlistUseCase {
+  final WishlistRepository repository;
+
+  AddToWishlistUseCase(this.repository);
+
+  Future<Either<Failure, void>> call(String productId) {
+    return repository.addToWishlist(productId);
+  }
+}

--- a/lib/domain/usecases/get_wishlist.dart
+++ b/lib/domain/usecases/get_wishlist.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import '../entities/wishlist_item.dart';
+import '../repositories/wishlist_repository.dart';
+import '../../core/failure.dart';
+
+class GetWishlistUseCase {
+  final WishlistRepository repository;
+
+  GetWishlistUseCase(this.repository);
+
+  Future<Either<Failure, List<WishlistItem>>> call() {
+    return repository.getWishlist();
+  }
+}

--- a/lib/domain/usecases/is_in_wishlist.dart
+++ b/lib/domain/usecases/is_in_wishlist.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../repositories/wishlist_repository.dart';
+import '../../core/failure.dart';
+
+class IsInWishlistUseCase {
+  final WishlistRepository repository;
+
+  IsInWishlistUseCase(this.repository);
+
+  Future<Either<Failure, bool>> call(String productId) {
+    return repository.isInWishlist(productId);
+  }
+}

--- a/lib/domain/usecases/remove_from_wishlist.dart
+++ b/lib/domain/usecases/remove_from_wishlist.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../repositories/wishlist_repository.dart';
+import '../../core/failure.dart';
+
+class RemoveFromWishlistUseCase {
+  final WishlistRepository repository;
+
+  RemoveFromWishlistUseCase(this.repository);
+
+  Future<Either<Failure, void>> call(String productId) {
+    return repository.removeFromWishlist(productId);
+  }
+}


### PR DESCRIPTION
This PR introduces the domain layer components for Wishlist functionality.

Added WishlistItem entity with fields: id, userId, productId.

Created WishlistRepository interface with methods to add, remove, and fetch wishlist items.

Added use cases:

AddToWishlistUseCase

RemoveFromWishlistUseCase

GetWishlistUseCase

This allows customers to save favorite products for later viewing, enhancing personalization and user engagement.